### PR TITLE
fix: set the correct autocomplete values

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -177,7 +177,7 @@
                  class="form-control"
                  id="field-town"
                  name="town"
-                 autocomplete="address-level1"
+                 autocomplete="address-level2"
                  aria-labelledby="field-town-label"
                  placeholder="Paris"
                  required
@@ -195,7 +195,7 @@
                  class="form-control"
                  id="field-zipcode"
                  name="zipcode"
-                 autocomplete="zipcode"
+                 autocomplete="postal-code"
                  minlength="4"
                  maxlength="5"
                  aria-labelledby="field-zipcode-label"


### PR DESCRIPTION
- city name: address-level1 to address-level2
- zip-code: zipcode to postal-code

From https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete